### PR TITLE
update sugarloaf parser

### DIFF
--- a/lib/resorts/sugarloaf/resort.json
+++ b/lib/resorts/sugarloaf/resort.json
@@ -2,7 +2,7 @@
   "name": "Sugarloaf",
   "url": {
     "host": "https://www.sugarloaf.com",
-    "pathname": "/conditions-and-cams"
+    "pathname": "/mountain-report"
   },
   "tags": [
     "New England",

--- a/lib/tools/boyne.js
+++ b/lib/tools/boyne.js
@@ -1,4 +1,18 @@
 module.exports = {
+  selector: '[id^="conditions_lifts"] + div + div + div:nth-child(2) + div ~ .breakInsideAvoid',
+  parse: {
+    name: '1',
+    status: {
+      child: '0/0',
+      attribute: 'alt',
+      // regex: /(?:-|icon-?)(\w+)\.(?:png|svg)$/i
+    }
+  }
+};
+
+
+/*
+module.exports = {
   selector: '[id^="conditions_lifts"] li > div',
   parse: {
     name: 1,
@@ -9,3 +23,4 @@ module.exports = {
     }
   }
 };
+*/

--- a/lib/tools/boyne.js
+++ b/lib/tools/boyne.js
@@ -5,22 +5,6 @@ module.exports = {
     status: {
       child: '0/0',
       attribute: 'alt',
-      // regex: /(?:-|icon-?)(\w+)\.(?:png|svg)$/i
     }
   }
 };
-
-
-/*
-module.exports = {
-  selector: '[id^="conditions_lifts"] li > div',
-  parse: {
-    name: 1,
-    status: {
-      child: '0/0',
-      attribute: 'src',
-      regex: /(?:-|icon-?)(\w+)\.(?:png|svg)$/i
-    }
-  }
-};
-*/

--- a/lib/tools/boyne.js
+++ b/lib/tools/boyne.js
@@ -1,5 +1,5 @@
 module.exports = {
-  selector: '[id^="conditions_lifts"] + div + div + div:nth-child(2) + div ~ .breakInsideAvoid',
+  selector: '[id^="conditions_lifts"] .breakInsideAvoid',
   parse: {
     name: '1',
     status: {


### PR DESCRIPTION
- it would seem that the status can be derived from the alt text for the icons
- liftie normalizes all status to lowercase, so it shouldn't be an issue sugarloaf has 'Closed' opposed to 'closed'
- the name of the lift comes from the adjacent div
![Screen Shot 2021-10-25 at 4 37 36 PM](https://user-images.githubusercontent.com/15982329/138767239-45f684c8-026a-4218-9554-b8dedb8867af.png)

